### PR TITLE
wscript: don't link libndn-cxx

### DIFF
--- a/wscript
+++ b/wscript
@@ -40,7 +40,7 @@ def configure(conf):
         os.environ['PKG_CONFIG_PATH'] = ':'.join([
             '/usr/local/lib/pkgconfig',
             '/opt/local/lib/pkgconfig'])
-    conf.check_cfg(package='libndn-cxx', args=['--cflags', '--libs'],
+    conf.check_cfg(package='libndn-cxx', args=['--cflags'],
                    uselib_store='NDN_CXX', mandatory=True)
 
     try:


### PR DESCRIPTION
libndn-cxx static library is already linked into ndnSIM dynamic library.
The scenario template shouldn't link it again, otherwise there would be
double free errors in ndn-cxx's global variables.

refs #2664